### PR TITLE
fix: database/sql.Scanner should not retain references

### DIFF
--- a/tests/scanner_valuer_test.go
+++ b/tests/scanner_valuer_test.go
@@ -170,10 +170,10 @@ func (data *EncryptedData) Scan(value interface{}) error {
 			return errors.New("Too short")
 		}
 
-		*data = b[3:]
+		*data = append((*data)[0:], b[3:]...)
 		return nil
 	} else if s, ok := value.(string); ok {
-		*data = []byte(s)[3:]
+		*data = []byte(s[3:])
 		return nil
 	}
 


### PR DESCRIPTION
Documentation for [`database/sql.Scanner`](https://pkg.go.dev/database/sql#Scanner) states that `Scan(src)` should not retain (i.e. it should *copy*) the `src` argument.

```go
// Reference types such as []byte are only valid until the next call to Scan
// and should not be retained. Their underlying memory is owned by the driver.
// If retention is necessary, copy their values before the next call to Scan.
```

This becomes an issue for this test if a driver returns a slice that is invalidated by [`rows.Close()`](sql#Rows.Close).

Copying the slice fixes this test failing with my [SQLite driver](https://github.com/ncruces/go-sqlite3).